### PR TITLE
remove the parse_obj step in training

### DIFF
--- a/decanter_ai_sdk/client.py
+++ b/decanter_ai_sdk/client.py
@@ -214,7 +214,7 @@ class Client:
             missing_value_settings=missing_value_settings,
         )
 
-        experiment = Experiment.parse_obj(self.wait_for_response("experiment", exp_id))
+        experiment = self.wait_for_response("experiment", exp_id)
 
         return experiment
 
@@ -324,7 +324,7 @@ class Client:
             seed=seed,
         )
 
-        experiment = Experiment.parse_obj(self.wait_for_response("experiment", exp_id))
+        experiment = self.wait_for_response("experiment", exp_id)
         return experiment
 
     def predict_iid(

--- a/decanter_ai_sdk/experiment.py
+++ b/decanter_ai_sdk/experiment.py
@@ -29,7 +29,6 @@ class Experiment(BaseModel):
     holdout: Dict[str, str]
     holdout_percentage: float
     is_binary_classification: bool
-    is_favorited: bool
     is_forecast: bool
     is_starred: bool
     max_model: int


### PR DESCRIPTION
The method "train_iid" and  "train_ts" in client.py execute the parse_obj before returning experiment info.
But the required field "is_favorited" which is recorded in class Experiment in experiment.py has been deprecated.
It makes the parse_obj step raise the exception and stop the execution.

I try to remove the parse_obj step, and let both "train_iid" and "train_ts" directly return the experiment info when the training is successful.