### PR TITLE
revert client.py

### DIFF
--- a/decanter_ai_sdk/client.py
+++ b/decanter_ai_sdk/client.py
@@ -214,7 +214,7 @@ class Client:
             missing_value_settings=missing_value_settings,
         )
 
-        experiment = self.wait_for_response("experiment", exp_id)
+        experiment = Experiment.parse_obj(self.wait_for_response("experiment", exp_id))
 
         return experiment
 
@@ -324,7 +324,7 @@ class Client:
             seed=seed,
         )
 
-        experiment = self.wait_for_response("experiment", exp_id)
+        experiment = Experiment.parse_obj(self.wait_for_response("experiment", exp_id))
         return experiment
 
     def predict_iid(

--- a/decanter_ai_sdk/web_api/data/iid_exp.json
+++ b/decanter_ai_sdk/web_api/data/iid_exp.json
@@ -354,7 +354,6 @@
      "validation_percentage": 0.1
    },
    "is_binary_classification": true,
-   "is_favorited": false,
    "is_forecast": false,
    "is_starred": false,
    "max_model": 5,

--- a/decanter_ai_sdk/web_api/data/ts_exp.json
+++ b/decanter_ai_sdk/web_api/data/ts_exp.json
@@ -1002,7 +1002,6 @@
     "validation_percentage": 0.1
   },
   "is_binary_classification": true,
-  "is_favorited": false,
   "is_forecast": true,
   "is_starred": false,
   "max_model": 5,


### PR DESCRIPTION
I misunderstand the method and found that we only need to remove "is_favorited" in the construction of the class Experiment.

So, make the parse_obj back to training.
And also remove the "is_favorited" in the test case.