### PR TITLE
add object 'hyperparameter' to experiment class

### DIFF
--- a/decanter_ai_sdk/client.py
+++ b/decanter_ai_sdk/client.py
@@ -214,7 +214,7 @@ class Client:
             missing_value_settings=missing_value_settings,
         )
 
-        experiment = self.wait_for_response("experiment", exp_id)
+        experiment = Experiment.parse_obj(self.wait_for_response("experiment", exp_id))
 
         return experiment
 
@@ -324,7 +324,7 @@ class Client:
             seed=seed,
         )
 
-        experiment = self.wait_for_response("experiment", exp_id)
+        experiment = Experiment.parse_obj(self.wait_for_response("experiment", exp_id))
         return experiment
 
     def predict_iid(

--- a/decanter_ai_sdk/experiment.py
+++ b/decanter_ai_sdk/experiment.py
@@ -28,7 +28,7 @@ class Experiment(BaseModel):
     gp_table_id: str
     holdout: Dict[str, str]
     holdout_percentage: float
-    hyperparameters: Dict[str,Any]
+    hyperparameters: Dict
     is_binary_classification: bool
     is_forecast: bool
     is_starred: bool

--- a/decanter_ai_sdk/experiment.py
+++ b/decanter_ai_sdk/experiment.py
@@ -28,6 +28,7 @@ class Experiment(BaseModel):
     gp_table_id: str
     holdout: Dict[str, str]
     holdout_percentage: float
+    hyperparameters: Dict[str,Any]
     is_binary_classification: bool
     is_forecast: bool
     is_starred: bool


### PR DESCRIPTION
There are some steps in the benchmark needing the hyperparameters of the experiment,
but the experiment class in the SDK does not contain this object.
Therefore, I add the object to the experiment class.