### PR TITLE
Feature/post upload should use multipart/form-data

### DIFF
--- a/decanter_ai_sdk/non_blocking_client.py
+++ b/decanter_ai_sdk/non_blocking_client.py
@@ -85,16 +85,17 @@ class NonBlockingClient:
         """
 
         if data is None:
-            raise ValueError("[Upload] Uploaded None file.")  # pragma: no cover
+            raise ValueError(
+                "[Upload] Uploaded None file.")  # pragma: no cover
 
         if isinstance(data, pd.DataFrame):
             text_stream = StringIO()
             data.to_csv(text_stream, index=False)
-            file = [("file", (name, text_stream.getvalue(), "text/csv"))]
+            file = (name, text_stream.getvalue(), "text/csv")
             text_stream.close()
 
         else:
-            file = [("file", (name, data, "text/csv"))]
+            file = (name, data, "text/csv")
         table_id = self.api.post_upload(file=file, name=name)
 
         return table_id
@@ -106,7 +107,8 @@ class NonBlockingClient:
         target: str,
         custom_column_types: Dict[str, DataType] = {},
         drop_features: List[str] = [],
-        evaluator: Optional[Union[RegressionMetric, ClassificationMetric]] = None,
+        evaluator: Optional[Union[RegressionMetric,
+                                  ClassificationMetric]] = None,
         holdout_table_id: Optional[str] = None,
         algos: Union[List[IIDAlgorithms], List[str]] = [
             IIDAlgorithms.DRF,
@@ -195,7 +197,8 @@ class NonBlockingClient:
             (`~decanter_ai_sdk.web_api.experiment.Experiment`)
                 Experiment id.
         """
-        data_column_info = self.api.get_table_info(table_id=experiment_table_id)
+        data_column_info = self.api.get_table_info(
+            table_id=experiment_table_id)
         # cast target column
         data_column_info[target] = custom_column_types[target].value
 
@@ -380,7 +383,8 @@ class NonBlockingClient:
             elif type(algo) == TSAlgorithms:
                 algo_values.append(algo.value)
 
-        data_column_info = self.api.get_table_info(table_id=experiment_table_id)
+        data_column_info = self.api.get_table_info(
+            table_id=experiment_table_id)
 
         features = [
             feature

--- a/decanter_ai_sdk/web_api/decanter_api.py
+++ b/decanter_ai_sdk/web_api/decanter_api.py
@@ -6,6 +6,7 @@ import pandas as pd
 import numpy as np
 
 from decanter_ai_sdk.web_api.api import ApiClient
+from requests_toolbelt import MultipartEncoder
 
 
 class DecanterApiClient(ApiClient):
@@ -17,11 +18,15 @@ class DecanterApiClient(ApiClient):
 
     def post_upload(self, file: Dict, name: str):  # pragma: no cover
 
+        m = MultipartEncoder(
+            fields={"project_id": self.project_id, "name": name, 'file': file[0][-1]})
+        headers = self.auth_headers
+        headers["Content-Type"] = m.content_type
+
         res = requests.post(
             f"{self.url}table/upload",
-            files=file,
-            data={"name": name, "project_id": self.project_id},
-            headers=self.auth_headers,
+            data=m,
+            headers=headers,
             verify=False,
         )
 

--- a/decanter_ai_sdk/web_api/decanter_api.py
+++ b/decanter_ai_sdk/web_api/decanter_api.py
@@ -16,10 +16,10 @@ class DecanterApiClient(ApiClient):
         self.project_id = project_id
         self.auth_headers = auth_headers
 
-    def post_upload(self, file: Dict, name: str):  # pragma: no cover
+    def post_upload(self, file: tuple, name: str):  # pragma: no cover
 
         m = MultipartEncoder(
-            fields={"project_id": self.project_id, "name": name, 'file': file[0][-1]})
+            fields={"project_id": self.project_id, "name": name, 'file': file})
         headers = self.auth_headers
         headers["Content-Type"] = m.content_type
 


### PR DESCRIPTION
This PR is for fixing the problem that the original post_upload method can not upload big data.

According to the example of corex sdk and WEB API docs, post_upload API should send a request with content-type "multipart/form-data".
I changed the post upload's payload schema in decanter_api.py,  and then tried to fix an inconvenient variable definition of "file" in non_blocking_client.py
As my testing with the AutoML benchmark, uploading big data is workable.