### PR TITLE
update package dependencies for dev purpose

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -23,7 +23,7 @@ tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pyte
 name = "black"
 version = "22.12.0"
 description = "The uncompromising code formatter."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -294,7 +294,7 @@ rapidfuzz = ">=2.2.0,<3.0.0"
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -559,7 +559,7 @@ pgp = ["gpg"]
 name = "exceptiongroup"
 version = "1.1.1"
 description = "Backport of PEP 654 (exception groups)"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -752,7 +752,7 @@ testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-chec
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1002,7 +1002,7 @@ reports = ["lxml"]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
 files = [
@@ -1052,7 +1052,7 @@ files = [
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1113,7 +1113,7 @@ test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 name = "pastel"
 version = "0.2.1"
 description = "Bring colors to your terminal."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
@@ -1125,7 +1125,7 @@ files = [
 name = "pathspec"
 version = "0.11.1"
 description = "Utility library for gitignore style pattern matching of file paths."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1179,7 +1179,7 @@ files = [
 name = "platformdirs"
 version = "2.6.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1195,7 +1195,7 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -1211,7 +1211,7 @@ testing = ["pytest", "pytest-benchmark"]
 name = "poethepoet"
 version = "0.16.5"
 description = "A task runner that works well with poetry."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1463,7 +1463,7 @@ files = [
 name = "pytest"
 version = "7.3.1"
 description = "pytest: simple powerful testing with Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1797,7 +1797,7 @@ files = [
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2037,4 +2037,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a7b0cabc45069431bd0cf2b71b321ff54f0b2e2ed3a1d8278192d8a644925a51"
+content-hash = "dfc4540912d10206366e330ce920898614d284bfdc5a9564040a82f3008858de"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,14 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.8"
 pandas = "^1.4.3"
-poethepoet = "^0.16.0"
 requests-toolbelt = "^0.9.1"
-black = "^22.6.0"
 tqdm = "^4.64.0"
-pytest = "^7.1.2"
 pydantic = "^1.9.2"
 urllib3 = "1.26.15"
 
 [tool.poetry.group.dev.dependencies]
+poethepoet = "^0.16.0"
+black = "^22.6.0"
 pytest = "^7.1.2"
 pytest-xdist = "^2.5.0"
 coveralls = "^3.3.1"


### PR DESCRIPTION
move dev dependencies to dev group inside pyproject.toml so that we won't install unnecessary packages during pip install.